### PR TITLE
Add support for SwiftPM-based dependency managers 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,8 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "WheelPicker"
+            name: "WheelPicker",
+            path: "WheelPicker"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "WheelPicker",
+    // platforms: [.iOS("9.0")],
     products: [
         .library(name: "WheelPicker", targets: ["WheelPicker"])
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "WheelPicker",
+    products: [
+        .library(name: "WheelPicker", targets: ["WheelPicker"])
+    ],
+    targets: [
+        .target(
+            name: "WheelPicker"
+        )
+    ]
+)


### PR DESCRIPTION
This adds a very basic [SwiftPM](https://github.com/apple/swift-package-manager) manifest file to be compatible with any dependency manager that uses Apples official way of specifying libraries.

Note that I created this PR because I'm currently developing a dependency manager called [Accio](https://github.com/JamitLabs/Accio) which is intended to fix several issues with Carthage and fill the gap between now and the time, when Apple adds official support for SwiftPM into Xcode. Merging this will also prepare for that bright future.